### PR TITLE
refactor: fix rule for private keys

### DIFF
--- a/cmd/generate/config/rules/privatekey.go
+++ b/cmd/generate/config/rules/privatekey.go
@@ -11,7 +11,7 @@ func PrivateKey() *config.Rule {
 	r := config.Rule{
 		Description: "Private Key",
 		RuleID:      "private-key",
-		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY----`),
+		Regex:       regexp.MustCompile(`(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY( BLOCK)?----`),
 		Keywords:    []string{"-----BEGIN"},
 	}
 
@@ -23,6 +23,9 @@ anything
 abcdefghijklmnopqrstuvwxyz
 -----END RSA PRIVATE KEY-----
 `,
+		`-----BEGIN PRIVATE KEY BLOCK-----
+anything
+-----END PRIVATE KEY BLOCK-----`
 	} // gitleaks:allow
 	return validate(r, tps, nil)
 }

--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -2411,7 +2411,7 @@ keywords = [
 [[rules]]
 description = "Private Key"
 id = "private-key"
-regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY----'''
+regex = '''(?i)-----BEGIN[ A-Z0-9_-]{0,100}PRIVATE KEY( BLOCK)?-----[\s\S-]*KEY( BLOCK)?----'''
 keywords = [
     "-----begin",
 ]


### PR DESCRIPTION
Wouldn't match old keys which have been created with the BLOCK statement at the beginning and end of the key.

### Description:
Explain the purpose of the PR.

### Checklist:

* [x] Does your PR pass tests?
* [x] Have you written new tests for your changes?
* [x] Have you lint your code locally prior to submission?
